### PR TITLE
Set delay between retry check for file uploaded to seconds

### DIFF
--- a/Fabric.Metadata.FileService.Client/FileUploader.cs
+++ b/Fabric.Metadata.FileService.Client/FileUploader.cs
@@ -171,7 +171,7 @@
                                 commitResult = await CheckCommitAsync(fileServiceClient, resourceId,
                                     uploadSession.SessionId, fileName);
                                 if (commitResult.StatusCode != HttpStatusCode.Accepted) break;
-                                await Task.Delay(SecondsToSleepBetweenCallingCheckCommit, cancellationToken);
+                                await Task.Delay(SecondsToSleepBetweenCallingCheckCommit * 1000, cancellationToken);
                             }
                         }
 


### PR DESCRIPTION
FileUploader.UploadFileAsync's retry was set to retry and check for a file to have been uploaded after 10ms, for a total time of 600ms. 
This was intended to be 10s delay, for a total delay of 10 minutes before throwing an error.